### PR TITLE
Fixes semver for windows dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ terminal_autoconfig = []
 lazy_static = "0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0"
+winapi = "0.2"
 kernel32-sys = "0"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ default = ["terminal_autoconfig"]
 terminal_autoconfig = []
 
 [dependencies]
-lazy_static = "0"
+lazy_static = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
-kernel32-sys = "0"
+kernel32-sys = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0"


### PR DESCRIPTION
Windows build fails as it attempts to use winapi 0.3, this sets version for winapi to 0.2 and all other dependencies to their current versions.