### PR TITLE
Fix Windows build errors by upgrading to Winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ terminal_autoconfig = []
 lazy_static = "0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0"
-kernel32-sys = "0"
+winapi = { version = "0.3", features = ["winbase","handleapi","consoleapi","processenv"] } 
+kernel32-sys = "0.2.2" 
 
 [target.'cfg(unix)'.dependencies]
 libc = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 keywords = ["cli", "clicolor", "clicolors", "colors"]
 license = "MIT"
-homepage = "https://github.com/mitsuhiko/clicolors-control"
+repository = "https://github.com/mitsuhiko/clicolors-control"
 documentation = "https://docs.rs/clicolors-control"
 readme = "README.md"
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,7 @@
-use winapi::{STD_OUTPUT_HANDLE, STD_ERROR_HANDLE, INVALID_HANDLE_VALUE};
-use kernel32::{GetStdHandle, GetConsoleMode, SetConsoleMode};
+use winapi::um::winbase::{STD_OUTPUT_HANDLE, STD_ERROR_HANDLE};
+use winapi::um::handleapi::{INVALID_HANDLE_VALUE};
+use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
+use winapi::um::processenv::{GetStdHandle};
 
 const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x4;
 


### PR DESCRIPTION
Think this crate started failing on Windows with the release of Winapi 0.3 which contained breaking major changes, and this crate specified version=0 instead of a specific version so automatically got the major changes and broke.

Have upgraded the winapi dependency and namespaces so now builds and tests runs on Windows.

Would be great to get this merged in and published together so the dependent crates (including `console` and `indicatif` that I'm using) starts working on Windows