### PR TITLE
Specify winapi version to 0.3 and update code to build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ terminal_autoconfig = []
 lazy_static = "0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0"
+winapi = { version = "0.3", features = ["handleapi", "winbase"] }
 kernel32-sys = "0"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,5 @@
-use winapi::{STD_OUTPUT_HANDLE, STD_ERROR_HANDLE, INVALID_HANDLE_VALUE};
+use winapi::um::winbase::{STD_OUTPUT_HANDLE, STD_ERROR_HANDLE};
+use winapi::um::handleapi::INVALID_HANDLE_VALUE;
 use kernel32::{GetStdHandle, GetConsoleMode, SetConsoleMode};
 
 const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x4;
@@ -28,7 +29,7 @@ pub fn is_a_color_terminal() -> bool {
 fn enable_ansi_on(handle: u32) -> bool {
     unsafe {
         let handle = GetStdHandle(handle);
-        if handle == INVALID_HANDLE_VALUE {
+        if handle == INVALID_HANDLE_VALUE as *mut ::std::os::raw::c_void {
             return false;
         }
 


### PR DESCRIPTION
This addresses #3. Maybe that unsafe pointer cast can be made more elegant.

It compiles now:
![clicolors_it_compiles](https://user-images.githubusercontent.com/2993230/34638547-b49adf08-f332-11e7-9427-d6f88f29cdb7.png)
