### PR TITLE
Bumped `lazy_static` to `1`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ default = ["terminal_autoconfig"]
 terminal_autoconfig = []
 
 [dependencies]
-lazy_static = "0"
+lazy_static = "1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase","handleapi","consoleapi","processenv"] } 
-kernel32-sys = "0.2.2" 
+winapi = { version = "0.3", features = ["winbase","handleapi","consoleapi","processenv"] }
+kernel32-sys = "0.2.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0"


### PR DESCRIPTION
Hiya, this PR seems out of the blue, but it's part of a set of PRs to try and update all my dependencies transitively.
This PR bumps `lazy_static`, and in turn `console` uses this crate, so that would need to also pick up a new version of this crate.
